### PR TITLE
ファイルを引数で選択できるように。EOFを除く処理

### DIFF
--- a/outcsv.js
+++ b/outcsv.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const files = [
+let files = [
   'scrDataBoss',
   'scrDataCinem',
   'scrDataMaps',
@@ -29,6 +29,17 @@ const files = [
   'scrDataTriggerVillage'
 ];
 
+let selectedFiles = [];
+if (process.argv.length > 2) {
+  for (let i = 2; i < process.argv.length; i++) {
+    const fileName = process.argv[i];
+    if (files.includes(fileName)) {
+      selectedFiles.push(fileName);
+    }
+  }
+  files = selectedFiles;
+}
+
 let sentenceCount = 0;
 let translatedCount = 0;
 let outData = 'key, ja, en, translated\n';
@@ -40,6 +51,9 @@ for (let i = 0; i < files.length; i++) {
   const jsonEn = JSON.parse(fs.readFileSync(`./en/${readFileName}`, 'utf8')).scr;
 
   for (const key in jsonJa) {
+    if (key === 'EOF') {
+      continue;
+    }
     const translated = jsonJa[key] !== jsonEn[key] ? 1 : 0;
     outData += `${key}, "${jsonJa[key]}", "${jsonEn[key]}", ${translated}\n`;
     sentenceCount++;


### PR DESCRIPTION
## 概要
特定のファイルを比較するための実装です。また、翻訳に関係ない文言（EOF）を除く処理も追加しました。

## 確認項目
- `node outcsv.js <filename>` で `filename` のみを比較したcsvファイルが出力される
- `node outcsv.js <filename1> <filename2>` で `filename1` と `filename2` を比較したcsvファイルが出力される
- csvファイルにEOFの列が含まれていない
